### PR TITLE
Fix typos in worskhop description

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,14 @@ eventbrite: # optional (insert the alphanumeric key for Eventbrite registration,
   giving a short lesson using approaches learned and implement some of
   the teaching techniques which we will discuss.  This is training for
   teaching, not technical training; you do not need any particular
-  technical background, and we will not be teaching that.This workshop
+  technical background, and we will not be teaching that. This workshop
   is based on the constantly revised and updated
  <a href="{{site.swc_githubio}}/instructor-training/">curriculum</a>.
 </p>
 
 <p>
   <strong>Who:</strong> The course is aimed at everyone who is
-  interested in becoming a better teacher. In particular, this trainig
+  interested in becoming a better teacher. In particular, this training
   is aimed at those who want to become Software and Data Carpentry
   instructors, run workshops and contribute to the Carpentry training
   materials.  You don't have to be currently an instructor or a


### PR DESCRIPTION
Fix two typos in workshop description. The workshop is over,
but this might still be read or copy-pasted for future workshops.
